### PR TITLE
remove reference to Configure: Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,17 +85,6 @@ docker run -it \
 	gremlin/gremlin daemon
 ```
 
-### Configure: Kubernetes
-
-To make the Gremlin daemonset run within the `gremlin.process` context, place the following `securityContext` into the existing Gremlin daemonset YAML.
-
-```yaml
-...
-securityContext:
-  seLinuxOptions:
-    type: gremlin.process
-```
-
 ### Configure: OpenShift
 
 Like [the configuration for kubernetes][config_kubernetes], the Gremlin daemonset must run with the `gremlin.process` SELinux context. For openshift, this should be controlled through a [SecurityContextConstraints][about_scc] policy instead of directly through a Kubernetes `securityContext`.


### PR DESCRIPTION
This section effectively configures the pod to relabel its bind-mounted files, which include important files on the host which should not be relabeled unless the user knows exactly what will happen.

This is likely not the best advice for users running on SELinux-enabled Kubernetes clusters. We need to find an equivalent to OpenShift's SecurityContextConstraints which configure what SELinux label the container process must run as, instead of relabeling the file system. Until we have that guidance, I think we should remove this.